### PR TITLE
Fix compilation esphome 2023.6

### DIFF
--- a/components/ds1302/ds1302.cpp
+++ b/components/ds1302/ds1302.cpp
@@ -34,7 +34,7 @@
 #include "ds1302.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
-#include "esphome/core/time.h
+#include "esphome/core/time.h"
 
 #define DS1302_CH_REG 0x80
 #define DS1302_WP_REG 0x8e

--- a/components/ds1302/ds1302.cpp
+++ b/components/ds1302/ds1302.cpp
@@ -34,6 +34,7 @@
 #include "ds1302.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/time.h
 
 #define DS1302_CH_REG 0x80
 #define DS1302_WP_REG 0x8e

--- a/components/ds1302/ds1302.cpp
+++ b/components/ds1302/ds1302.cpp
@@ -86,7 +86,7 @@ void DS1302Component::read_time() {
     ESP_LOGW(TAG, "RTC halted, not syncing to system clock.");
     return;
   }
-  time::ESPTime rtc_time{.second = uint8_t(ds1302_.reg.second + 10 * ds1302_.reg.second_10),
+  ESPTime rtc_time{.second = uint8_t(ds1302_.reg.second + 10 * ds1302_.reg.second_10),
                          .minute = uint8_t(ds1302_.reg.minute + 10u * ds1302_.reg.minute_10),
                          .hour = uint8_t(ds1302_.reg.hour + 10u * ds1302_.reg.hour_10),
                          .day_of_week = uint8_t(ds1302_.reg.weekday),


### PR DESCRIPTION
Hi, this fixes the breaking change for custom components using ESPTime in Esphome 2023.6

See https://github.com/esphome/esphome/pull/4926

Great custom component btw, i just used it to set my xy clock up in combination with https://github.com/FatBeard/xy-wifi-clock-component. You may want to squash the commit messages when merging.