### PR TITLE
#include "esphome/core/version.h"

### DIFF
--- a/components/ds1302/ds1302.cpp
+++ b/components/ds1302/ds1302.cpp
@@ -34,6 +34,8 @@
 #include "ds1302.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/version.h"
+
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 6, 0)
 #include "esphome/core/time.h"
 #endif
@@ -90,7 +92,7 @@ void DS1302Component::read_time() {
     return;
   }
 /* retain backward compatibility. see https://github.com/esphome/esphome/pull/4926 */
-#if ESPHOME_VERSION_CODE > VERSION_CODE(2022, 9, 1)
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 6, 0)
   ESPTime rtc_time{.second = uint8_t(ds1302_.reg.second + 10 * ds1302_.reg.second_10),
                    .minute = uint8_t(ds1302_.reg.minute + 10u * ds1302_.reg.minute_10),
                    .hour = uint8_t(ds1302_.reg.hour + 10u * ds1302_.reg.hour_10),


### PR DESCRIPTION
Looks like since 2023.8.1 need to have "#include "esphome/core/version.h" to do a version compare.

Also, looks like it was comparing one section to 2022.9.1 instead of 2023.6.0 which was the last version before ESPTime was moved to a "helper."